### PR TITLE
docs: add README for OctoAcme project management docs (adds overview + links)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+```markdown
+# OctoAcme Project Management Docs — README
+
+## About these docs
+This collection centralizes OctoAcme's project management practices so teams can consistently plan, deliver, and improve product and engineering work. The docs live in docs/ and include templates, checklists, and step-by-step guidance for initiation, planning, execution, release, risk management, and retrospectives. These materials are living references — update them in the repo as processes evolve.
+
+## Brief overview of OctoAcme processes
+OctoAcme follows an iterative, customer-focused delivery model with clear role ownership. Each project names a Project Manager (PM) and Product Lead (PdM) who share responsibility for outcomes and stakeholder alignment. Work begins with a lightweight Project One-pager (problem, goal, success metrics) used to gate planning. Planning breaks approved initiatives into shippable backlog items, defines a Definition of Done, and captures cross-team dependencies and risks in a simple risk register.
+
+Execution emphasizes small, testable increments and visible workflow boards (Backlog → Ready → In Progress → In Review → QA → Done). Development uses small pull requests, linked issues, CI with tests and security scans, and at least one reviewer approval before merges. Releases are gated by passing CI, drafted release notes, smoke tests in staging, and a rollback/mitigation plan. Quality is ensured through a blend of automated unit/integration tests, end-to-end smoke tests for critical flows, and targeted manual QA as needed.
+
+Communication and continuous improvement are explicit: teams run daily standups for blockers, weekly delivery syncs for progress and risks, end-of-sprint demos, and regular stakeholder updates. Escalation paths run from team triage → PM → Product Lead → Sponsor (with a separate path for security incidents). Retrospectives after sprints, releases, or incidents produce prioritized action items that are tracked back into the backlog with owners and due dates.
+
+## Key process documents
+- [Project Management Overview](docs/octoacme-project-management-overview.md)
+- [Project Initiation Guide](docs/octoacme-project-initiation.md)
+- [Project Planning](docs/octoacme-project-planning.md)
+- [Execution & Tracking](docs/octoacme-execution-and-tracking.md)
+- [Release & Deployment Guide](docs/octoacme-release-and-deployment.md)
+- [Risk Management & Communication](docs/octoacme-risks-and-communication.md)
+- [Retrospective & Continuous Improvement](docs/octoacme-retrospective-and-continuous-improvement.md)
+- [Roles & Personas](docs/octoacme-roles-and-personas.md)
+
+## How to use this README
+- Use it as the single entry point to familiarize new team members with OctoAcme's delivery practices.
+- Keep the Project One-pager and project-specific artifacts up to date in each project repo.
+- If you update a process doc, update this README to keep links and summaries current.
+
+## Acceptance Criteria (from issue #2)
+- [ ] Content aligns with existing process docs
+- [ ] Update improves clarity or closes a documented gap
+- [ ] Proposed content has been reviewed with stakeholders (if needed)
+```


### PR DESCRIPTION
Adds docs/README.md introducing OctoAcme project management practices and quick links to core process documents.